### PR TITLE
Correct URL for project license

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![License](https://img.shields.io/badge/license-MIT-green.svg?style=flat)](https://github.com/ustwo/formvalidator-swift/blob/master/LICENSE)
+[![License](https://img.shields.io/badge/license-MIT-green.svg?style=flat)](https://github.com/ustwo/formvalidator-swift/blob/master/LICENSE.md)
 [![Build Status](https://travis-ci.org/ustwo/formvalidator-swift.svg?branch=master)](https://travis-ci.org/ustwo/formvalidator-swift)
 [![codecov.io](https://codecov.io/github/ustwo/formvalidator-swift/coverage.svg?branch=master)](https://codecov.io/github/ustwo/formvalidator-swift?branch=master)
 ![Swift](https://img.shields.io/badge/Swift-3.0-orange.svg)


### PR DESCRIPTION
Current URL results in 404. Updated to correct license.

