### PR TITLE
Feature/issue 43 fix should allow violation

### DIFF
--- a/Example/FormAccessibility.swift
+++ b/Example/FormAccessibility.swift
@@ -20,6 +20,9 @@ struct FormAccessibility {
         static let NameLabel        = "NAME_LABEL"
         static let NameTextField    = "NAME_TEXTFIELD"
         
+        static let TitleLabel       = "TITLE_LABEL"
+        static let TitleTextField   = "TITLE_TEXTFIELD"
+        
         static let SubmitButton     = "SUBMIT_BUTTON"
     }
     

--- a/Example/FormView.swift
+++ b/Example/FormView.swift
@@ -46,7 +46,7 @@ final class FormView: UIView {
         addSubview(stackView)
         
         titleEntry.textLabel.text = NSLocalizedString("Title", comment: "")
-        emailEntry.textField.shouldAllowViolation = true
+        titleEntry.textField.shouldAllowViolation = true
         stackView.addArrangedSubview(titleEntry)
         
         nameEntry.textLabel.text = NSLocalizedString("Surname", comment: "")

--- a/Example/FormView.swift
+++ b/Example/FormView.swift
@@ -16,6 +16,7 @@ final class FormView: UIView {
     
     // MARK: - Properties
     
+    let titleEntry      = FormEntryView<AlphabeticValidator>()
     let nameEntry       = FormEntryView<AlphabeticValidator>()
     let emailEntry      = FormEntryView<EmailValidator>()
     
@@ -44,6 +45,10 @@ final class FormView: UIView {
         stackView.alignment = .fill
         addSubview(stackView)
         
+        titleEntry.textLabel.text = NSLocalizedString("Title", comment: "")
+        emailEntry.textField.shouldAllowViolation = true
+        stackView.addArrangedSubview(titleEntry)
+        
         nameEntry.textLabel.text = NSLocalizedString("Surname", comment: "")
         stackView.addArrangedSubview(nameEntry)
         
@@ -62,6 +67,9 @@ final class FormView: UIView {
         
         
         // Accessibility
+        
+        titleEntry.textLabel.accessibilityIdentifier = FormAccessibility.Identifiers.TitleLabel
+        titleEntry.textField.accessibilityIdentifier = FormAccessibility.Identifiers.TitleTextField
         
         nameEntry.textLabel.accessibilityIdentifier = FormAccessibility.Identifiers.NameLabel
         nameEntry.textField.accessibilityIdentifier = FormAccessibility.Identifiers.NameTextField

--- a/FormValidatorSwift.xcodeproj/project.pbxproj
+++ b/FormValidatorSwift.xcodeproj/project.pbxproj
@@ -133,6 +133,8 @@
 		00F2E2E01C46C6F400FE0B66 /* PresentConditionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00F2E2DF1C46C6F400FE0B66 /* PresentConditionTests.swift */; };
 		00F2E2E21C46C7B500FE0B66 /* PasswordStrengthCondition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00F2E2E11C46C7B500FE0B66 /* PasswordStrengthCondition.swift */; };
 		00F2E2E41C46CBC200FE0B66 /* PasswordStrengthConditionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00F2E2E31C46CBC200FE0B66 /* PasswordStrengthConditionTests.swift */; };
+		88644DA71E2967F7006B0150 /* ValidatorTextFieldTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88644DA61E2967F7006B0150 /* ValidatorTextFieldTests.swift */; };
+		88644DA91E296AEC006B0150 /* ValidatorTextViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88644DA81E296AEC006B0150 /* ValidatorTextViewTests.swift */; };
 		BAF88F201DCA3BFF001845D1 /* CreditCardCondition.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAF88F1F1DCA3BFF001845D1 /* CreditCardCondition.swift */; };
 		BAF88F221DCA3BFF001845D1 /* CreditCardCondition.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAF88F1F1DCA3BFF001845D1 /* CreditCardCondition.swift */; };
 		BAF88F261DCA4166001845D1 /* CreditCardValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAF88F251DCA4166001845D1 /* CreditCardValidator.swift */; };
@@ -241,6 +243,8 @@
 		00F2E2DF1C46C6F400FE0B66 /* PresentConditionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PresentConditionTests.swift; sourceTree = "<group>"; };
 		00F2E2E11C46C7B500FE0B66 /* PasswordStrengthCondition.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PasswordStrengthCondition.swift; sourceTree = "<group>"; };
 		00F2E2E31C46CBC200FE0B66 /* PasswordStrengthConditionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PasswordStrengthConditionTests.swift; sourceTree = "<group>"; };
+		88644DA61E2967F7006B0150 /* ValidatorTextFieldTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ValidatorTextFieldTests.swift; path = Controls/ValidatorTextFieldTests.swift; sourceTree = "<group>"; };
+		88644DA81E296AEC006B0150 /* ValidatorTextViewTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ValidatorTextViewTests.swift; path = Controls/ValidatorTextViewTests.swift; sourceTree = "<group>"; };
 		BA6C8FAD1DC77E2200AFE4C4 /* tr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = tr; path = tr.lproj/Localizable.strings; sourceTree = "<group>"; };
 		BAF88F1F1DCA3BFF001845D1 /* CreditCardCondition.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CreditCardCondition.swift; sourceTree = "<group>"; };
 		BAF88F251DCA4166001845D1 /* CreditCardValidator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CreditCardValidator.swift; sourceTree = "<group>"; };
@@ -300,6 +304,7 @@
 			isa = PBXGroup;
 			children = (
 				0032C10B1C4559260023DB19 /* Conditions */,
+				88644DA51E2967B1006B0150 /* Controls */,
 				003E06231C463E5B008D47F2 /* Extensions */,
 				003698301C46DE00004D1692 /* Validators */,
 				002C042A1C454AD9005CC374 /* Info.plist */,
@@ -479,6 +484,15 @@
 				0094D69E1C46B39800145F5C /* OrConditionTests.swift */,
 			);
 			path = Logic;
+			sourceTree = "<group>";
+		};
+		88644DA51E2967B1006B0150 /* Controls */ = {
+			isa = PBXGroup;
+			children = (
+				88644DA61E2967F7006B0150 /* ValidatorTextFieldTests.swift */,
+				88644DA81E296AEC006B0150 /* ValidatorTextViewTests.swift */,
+			);
+			name = Controls;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -823,6 +837,7 @@
 				00F2E2E01C46C6F400FE0B66 /* PresentConditionTests.swift in Sources */,
 				004913C51C47C74400471F53 /* PresentValidatorTests.swift in Sources */,
 				BAF88F2C1DCA4201001845D1 /* CreditCardConditionTests.swift in Sources */,
+				88644DA71E2967F7006B0150 /* ValidatorTextFieldTests.swift in Sources */,
 				003E06251C463E84008D47F2 /* XCTestCase+Additions.swift in Sources */,
 				0094D67D1C46992C00145F5C /* NumericConditionTests.swift in Sources */,
 				004913BD1C47C56900471F53 /* EmailValidatorTests.swift in Sources */,
@@ -839,6 +854,7 @@
 				00F2E2D81C46C47700FE0B66 /* AndConditionTests.swift in Sources */,
 				004913C31C47C6F900471F53 /* PasswordStrengthValidatorTests.swift in Sources */,
 				0032C10D1C45594E0023DB19 /* AlphabeticConditionTests.swift in Sources */,
+				88644DA91E296AEC006B0150 /* ValidatorTextViewTests.swift in Sources */,
 				004913C91C47C7E500471F53 /* URLShorthandValidatorTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Sources/Controls/ValidatorTextField.swift
+++ b/Sources/Controls/ValidatorTextField.swift
@@ -14,7 +14,7 @@ open class ValidatorTextField: UITextField, ValidatorControl {
     
     // MARK: - Properties
     
-    open var shouldAllowViolation = true
+    open var shouldAllowViolation = false
     open var validateOnFocusLossOnly = false
     open let validator: Validator
     /// Validator delegate for the text field.
@@ -130,7 +130,7 @@ internal class ValidatorTextFieldResponder: NSObject, UITextFieldDelegate {
         
         if !validatorTextField.validateOnFocusLossOnly && range.location != 0,
             let conditions = conditions,
-            (!validatorTextField.shouldAllowViolation || conditions[0].shouldAllowViolation) {
+            (!validatorTextField.shouldAllowViolation || !conditions[0].shouldAllowViolation) {
                 return false
         }
         

--- a/Sources/Controls/ValidatorTextView.swift
+++ b/Sources/Controls/ValidatorTextView.swift
@@ -14,7 +14,7 @@ open class ValidatorTextView: UITextView, ValidatorControl {
     
     // MARK: - Properties
     
-    open var shouldAllowViolation = true
+    open var shouldAllowViolation = false
     open var validateOnFocusLossOnly = false
     open let validator: Validator
     /// Validator delegate for the text view.

--- a/Tests/UI Tests/FormTests.swift
+++ b/Tests/UI Tests/FormTests.swift
@@ -66,12 +66,17 @@ class FormTests: XCTestCase {
     func testForm_Valid() {
         let app = XCUIApplication()
         
+        let title = "Developer"
         let name = "Foo"
         let email = "Bar@Baz.com"
         
+        let titleTextField = app.textFields[FormAccessibility.Identifiers.TitleTextField]
         let nameTextField = app.textFields[FormAccessibility.Identifiers.NameTextField]
         let emailTextField = app.textFields[FormAccessibility.Identifiers.EmailTextField]
         let submitButton = app.buttons[FormAccessibility.Identifiers.SubmitButton]
+        
+        titleTextField.tap()
+        titleTextField.typeText(title)
         
         nameTextField.tap()
         nameTextField.typeText(name)
@@ -91,12 +96,17 @@ class FormTests: XCTestCase {
     func testForm_Invalid() {
         let app = XCUIApplication()
         
+        let title = "Developer"
         let name = "Foo"
         let email = "Bar"
         
+        let titleTextField = app.textFields[FormAccessibility.Identifiers.TitleTextField]
         let nameTextField = app.textFields[FormAccessibility.Identifiers.NameTextField]
         let emailTextField = app.textFields[FormAccessibility.Identifiers.EmailTextField]
         let submitButton = app.buttons[FormAccessibility.Identifiers.SubmitButton]
+        
+        titleTextField.tap()
+        titleTextField.typeText(title)
         
         nameTextField.tap()
         nameTextField.typeText(name)

--- a/Tests/UI Tests/FormTests.swift
+++ b/Tests/UI Tests/FormTests.swift
@@ -39,6 +39,19 @@ class FormTests: XCTestCase {
     
     func testTextField_AllowedViolations() {
         let app = XCUIApplication()
+        let expectedResult = "Foo12"
+        
+        let titleTextField = app.textFields[FormAccessibility.Identifiers.TitleTextField]
+        titleTextField.tap()
+        titleTextField.typeText(expectedResult)
+        
+        let actualResult = titleTextField.value as? String
+        
+        XCTAssertEqual(actualResult, expectedResult, "The text field should have text \(expectedResult) but received \(actualResult).")
+    }
+    
+    func testTextField_AllowedViolations_and_validateOnFocusLossOnly() {
+        let app = XCUIApplication()
         let expectedResult = "Foo12 ?"
         
         let emailTextField = app.textFields[FormAccessibility.Identifiers.EmailTextField]

--- a/Tests/Unit Tests/Controls/ValidatorTextFieldTests.swift
+++ b/Tests/Unit Tests/Controls/ValidatorTextFieldTests.swift
@@ -1,0 +1,37 @@
+//
+//  ValidatorTextFieldTests.swift
+//  FormValidatorSwift
+//
+//  Created by John Mann on 1/13/17.
+//  Copyright © 2017 ustwo. All rights reserved.
+//
+
+import XCTest
+
+@testable import FormValidatorSwift
+
+class ValidatorTextFieldTests: XCTestCase {
+    
+    func testAlphabeticCondition_DefaultInit() {
+        // Given
+        let validatorTextField = ValidatorTextField(validator: AlphabeticValidator())
+        let expectShouldAllowViolation = false
+        let expectValidateOnFocusLossOnly = false
+        
+        // When
+        let actualShouldAllowViolation = validatorTextField.shouldAllowViolation
+        let actualValidateOnFocusLossOnly = validatorTextField.validateOnFocusLossOnly
+        
+        // Test
+        XCTAssertEqual(actualShouldAllowViolation,
+                       expectShouldAllowViolation,
+                       "Expected shouldAllowViolation to be: \(expectShouldAllowViolation) but found: \(actualShouldAllowViolation)")
+        
+        // Test
+        XCTAssertEqual(actualValidateOnFocusLossOnly,
+                       expectValidateOnFocusLossOnly,
+                       "Expected validateOnFocusLossOnly to be: \(expectValidateOnFocusLossOnly) but found: \(actualValidateOnFocusLossOnly)")
+    }
+    
+    
+}

--- a/Tests/Unit Tests/Controls/ValidatorTextViewTests.swift
+++ b/Tests/Unit Tests/Controls/ValidatorTextViewTests.swift
@@ -1,0 +1,37 @@
+//
+//  ValidatorTextViewTests.swift
+//  FormValidatorSwift
+//
+//  Created by John Mann on 1/13/17.
+//  Copyright © 2017 ustwo. All rights reserved.
+//
+
+import XCTest
+
+@testable import FormValidatorSwift
+
+class ValidatorTextViewTests: XCTestCase {
+    
+    func testAlphabeticCondition_DefaultInit() {
+        // Given
+        let validatorTextView = ValidatorTextView(validator: AlphabeticValidator())
+        let expectShouldAllowViolation = false
+        let expectValidateOnFocusLossOnly = false
+        
+        // When
+        let actualShouldAllowViolation = validatorTextView.shouldAllowViolation
+        let actualValidateOnFocusLossOnly = validatorTextView.validateOnFocusLossOnly
+        
+        // Test
+        XCTAssertEqual(actualShouldAllowViolation,
+                       expectShouldAllowViolation,
+                       "Expected shouldAllowViolation to be: \(expectShouldAllowViolation) but found: \(actualShouldAllowViolation)")
+        
+        // Test
+        XCTAssertEqual(actualValidateOnFocusLossOnly,
+                       expectValidateOnFocusLossOnly,
+                       "Expected validateOnFocusLossOnly to be: \(expectValidateOnFocusLossOnly) but found: \(actualValidateOnFocusLossOnly)")
+    }
+    
+    
+}


### PR DESCRIPTION
### Summary

This fixes `ValidatorTextField` and `ValidatorTextView` to behave correctly when the `shouldAllowViolation` property is set to `true`.  

This also changes `ValidatorTextField` and `ValidatorTextView` to initialize with a default of `false` for the `shouldAllowViolation` property.  Doing this better matches the intent of the documentation.

See issue `#43` for more detail.